### PR TITLE
Support garage door opening time parameter.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -89,12 +89,6 @@
         "placeholder": "Living Room Switch",
         "required": true
       },
-      "deviceUuid": {
-        "title": "Device UUID",
-        "description": "Device UUID, seems it still works well even it's empty",
-        "type": "string",
-        "required": false
-      },
       "deviceUrl": {
         "title": "IP Address",
         "description": "The device's IP address. It is recommended to set a static IP for the device.",
@@ -125,6 +119,44 @@
         "title": "Sign",
         "type": "string",
         "required": true
+      },
+      "garageDoorOpeningTime": {
+        "title": "Garage Door Opening Time",
+        "description": "Different garage door openers may take different time duration to open or close garage door. Please choose the proper time duration below for your garage door opener so that app can use it as a timeout parameter to confirm the status of your garage.",
+        "type": "integer",
+        "default": 20,
+        "placeholder": 20,
+        "required": false,
+        "oneOf": [
+          {
+            "title": "10 seconds",
+            "enum": [10]
+          },
+          {
+            "title": "15 seconds",
+            "enum": [15]
+          },
+          {
+            "title": "20 seconds",
+            "enum": [20]
+          },
+          {
+            "title": "25 seconds",
+            "enum": [25]
+          },
+          {
+            "title": "30 seconds",
+            "enum": [30]
+          },
+          {
+            "title": "35 seconds",
+            "enum": [35]
+          },
+          {
+            "title": "40 seconds",
+            "enum": [40]
+          }
+        ]
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -527,9 +527,9 @@ class Meross {
         const currentTime = Math.floor(Date.now() / 1000);
         const elapsedTime = currentTime - this.lastSetTime;
         if (this.currentState === Characteristic.CurrentDoorState.OPENING) {
-          this.currentState = elapsedTime < 20 ? Characteristic.CurrentDoorState.OPENING : Characteristic.CurrentDoorState.OPEN;
+          this.currentState = elapsedTime < this.config.garageDoorOpeningTime ? Characteristic.CurrentDoorState.OPENING : Characteristic.CurrentDoorState.OPEN;
         } else if (this.currentState === Characteristic.CurrentDoorState.CLOSING) {
-          this.currentState = elapsedTime < 20 ? Characteristic.CurrentDoorState.CLOSING : Characteristic.CurrentDoorState.OPEN;
+          this.currentState = elapsedTime < this.config.garageDoorOpeningTime ? Characteristic.CurrentDoorState.CLOSING : Characteristic.CurrentDoorState.OPEN;
         } else {
           this.currentState =  Characteristic.CurrentDoorState.OPEN
         }
@@ -580,7 +580,7 @@ class Meross {
     // Stop updating after 22 seconds
     self.checkStateTimeout = setTimeout(function () {
       self.stopRequestingDoorState();
-    }, 22000);
+    }, this.config.garageDoorOpeningTime * 1000 + 2000);
   }
 
   stopRequestingDoorState() {


### PR DESCRIPTION
- Removed the unused `Device UUID` parameter
- Added `Garage Door Opening Time` parameter, to better determine the opening duration. It's actually a setting in the official app, so it's better to match the same setting in Homebridge.