### PR TITLE
Get garage door status change notification by requesting status every 2s all the time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
+## Next (2020-06-16)
+
+## [Version Next](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v2.2.0...2.X.X)
+
+#### Changes
+-  (#41) Thanks CocoaBob!
+
 ## 2.2.0 (2020-06-16)
 
 ## [Version 2.2.0](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v2.1.0...2.2.0)

--- a/index.js
+++ b/index.js
@@ -565,6 +565,11 @@ class Meross {
       })
       .catch( e => this.log.debug(`${e}`));
     }, 2000);
+    
+    // Stop updating after 22 seconds
+    self.checkStateTimeout = setTimeout(function () {
+      self.stopRequestingDoorState();
+    }, this.config.garageDoorOpeningTime * 1000 + 2000);
   }
 
   stopUpdatingDoorState() {

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ class Meross {
         break;
       case "MSG100":
         this.service = new Service.GarageDoorOpener(this.config.name);
+        this.startUpdatingDoorState()
         break;
       default:
         this.service = new Service.Outlet(this.config.name);
@@ -372,9 +373,6 @@ class Meross {
 
     this.log.debug(`setDoorStateHandler ${value} for ${this.config.model} at ${this.config.deviceUrl}...`);
 
-    // Stop requesting state
-    this.stopRequestingDoorState()
-
     let self = this;
     this.getDoorState()
     .then(function(state) {
@@ -441,11 +439,6 @@ class Meross {
           self.log("Target OPEN, Current UNKOWN, no change");
           callback();
         }
-      }
-
-      if (self.currentState === Characteristic.CurrentDoorState.OPENING ||
-         self.currentState === Characteristic.CurrentDoorState.CLOSING) {
-        self.startRequestingDoorState()
       }
     })
     .catch(function(error) {
@@ -561,32 +554,21 @@ class Meross {
     return this.currentState;
   }
 
-  startRequestingDoorState() {
-    this.stopRequestingDoorState()
+  startUpdatingDoorState() {
+    this.stopUpdatingDoorState()
     let self = this;
     // Update state repeatedly
     self.checkStateInterval = setInterval(function() {
       self.getDoorState()
       .then(function (state) {
         self.service.setCharacteristic(Characteristic.CurrentDoorState, state);
-        if (state != Characteristic.CurrentDoorState.OPENING && state != Characteristic.CurrentDoorState.CLOSING) {
-          self.stopRequestingDoorState();
-        }
       })
-      .catch(function(error) {
-        self.stopRequestingDoorState();
-      });
+      .catch( e => this.log.debug(`${e}`));
     }, 2000);
-    // Stop updating after 22 seconds
-    self.checkStateTimeout = setTimeout(function () {
-      self.stopRequestingDoorState();
-    }, this.config.garageDoorOpeningTime * 1000 + 2000);
   }
 
-  stopRequestingDoorState() {
+  stopUpdatingDoorState() {
     clearInterval(this.checkStateInterval);
     this.checkStateInterval = undefined;
-    clearTimeout(this.checkStateTimeout);
-    this.checkStateTimeout = undefined;
   }
 }


### PR DESCRIPTION
The purpose of doing this is to get status change notifications in real time, since we can't receive  push notifications like Meross official app (I sniffed it, they use APNS when app isn't running, and use Socket connection when app is running). The only way to get notifications for us, is updating status all the time.

I think we could make it more general for all other device types, like the smart switches. And I don't know if it's necessary to make it optional, since it must cost more energy if we send HTTP requests to Meross hardwares every 2 seconds all the time.

Anyway, I've been testing it for 24 hours, both my two garage openers are working well.